### PR TITLE
Enable filename suffix for saved panels

### DIFF
--- a/src/mpl_panel_builder/panel_builder.py
+++ b/src/mpl_panel_builder/panel_builder.py
@@ -66,8 +66,13 @@ class PanelBuilder:
                 f"{', '.join(missing)}"
             )
 
-    def __call__(self) -> MatplotlibFigure:
+    def __call__(self, *args: Any, **kwargs: Any) -> MatplotlibFigure:
         """Initializes and builds the panel, returning the resulting figure.
+
+        Any positional and keyword arguments are forwarded to
+        :meth:`build_panel`. If :meth:`build_panel` returns a string, it is
+        treated as a filename *suffix* appended to :pyattr:`panel_name` when the
+        panel is saved. Returning ``None`` keeps the default filename.
 
         Returns:
             MatplotlibFigure: The constructed matplotlib figure.
@@ -77,17 +82,19 @@ class PanelBuilder:
             self._fig = self.create_fig()
             self.draw_debug_lines()
             self._axs_grid = self.create_axes()
-            self.build_panel()
-            self.save_fig()
+            filename_suffix = self.build_panel(*args, **kwargs)
+            self.save_fig(filename_suffix if isinstance(filename_suffix, str) else None)
         return self.fig
 
-    def build_panel(self) -> None:
+    def build_panel(self, *args: Any, **kwargs: Any) -> Any:
         """Populates the panel with plot content.
-        
-        This method should be implemented by subclasses to create the actual plot 
-        content. The base implementation raises NotImplementedError since each panel 
-        implementation should provide its own visualization logic.
-        
+
+        Subclasses should implement their plotting logic here.  The return value
+        may optionally be a string which will be appended to
+        :pyattr:`panel_name` when the panel is saved.  Any positional and
+        keyword arguments passed to :py:meth:`__call__` are forwarded to this
+        method.
+
         Raises:
             NotImplementedError: This method must be implemented by subclasses.
         """
@@ -279,21 +286,29 @@ class PanelBuilder:
         else:
             raise ValueError(f"Invalid dimension: {dim}")
         
-    def save_fig(self) -> None:
-        """Saves the figure to the output directory."""
+    def save_fig(self, filename_suffix: str | None = None) -> None:
+        """Saves the figure to the output directory.
+
+        Args:
+            filename_suffix: Optional string to append to
+                :pyattr:`panel_name` when naming the saved file.
+        """
         # Check if output directory is set
         # TODO: Add logging to inform the user that the figure has been saved
         if self.config.panel_output.directory:
-        
+
             # Check if the directory exists
             directory = Path(self.config.panel_output.directory)
             if not directory.exists():
                 raise ValueError(f"Output directory does not exist: {directory}")
-            
+
             # Save the figure
             file_format = self.config.panel_output.format
             dpi = self.config.panel_output.dpi
-            self.fig.savefig(directory / f"{self.panel_name}.{file_format}", dpi=dpi)
+            panel_name = self.panel_name
+            if filename_suffix:
+                panel_name = f"{panel_name}_{filename_suffix}"
+            self.fig.savefig(directory / f"{panel_name}.{file_format}", dpi=dpi)
         
 
     @property

--- a/tests/test_panel_builder.py
+++ b/tests/test_panel_builder.py
@@ -1,4 +1,5 @@
-from typing import TypeAlias
+import pathlib
+from typing import Any, TypeAlias
 
 import matplotlib
 import pytest
@@ -8,7 +9,7 @@ from matplotlib.figure import Figure as MatplotlibFigure
 
 from mpl_panel_builder.panel_builder import PanelBuilder
 
-ConfigDict: TypeAlias = dict[str, dict[str, float]]
+ConfigDict: TypeAlias = dict[str, dict[str, Any]]
 
 
 def make_dummy_panel_class(
@@ -166,3 +167,35 @@ def test_fig_has_correct_margins(sample_config_dict: ConfigDict) -> None:
     assert pytest.approx(ax.get_position().y0) == expected_y
     assert pytest.approx(ax.get_position().width) == expected_width
     assert pytest.approx(ax.get_position().height) == expected_height
+
+
+def test_filename_suffix(
+    tmp_path: pathlib.Path, sample_config_dict: ConfigDict
+) -> None:
+    """Suffix returned from ``build_panel`` is appended to ``panel_name``."""
+
+    class CustomPanel(PanelBuilder):
+        panel_name = "dummy_panel"
+        n_rows = 1
+        n_cols = 1
+
+        def build_panel(self, suffix: str | None = None) -> str | None:
+            self.axs_grid[0][0].plot([0, 1], [0, 1])
+            return suffix
+
+    config = dict(sample_config_dict)
+    config["panel_output"] = {
+        "directory": str(tmp_path),
+        "format": "png",
+        "dpi": 72,
+    }
+
+    # Without suffix → default filename
+    builder = CustomPanel(config)
+    builder()
+    assert (tmp_path / "dummy_panel.png").exists()
+
+    # With suffix → suffix appended
+    builder = CustomPanel(config)
+    builder(suffix="alt")
+    assert (tmp_path / "dummy_panel_alt.png").exists()


### PR DESCRIPTION
## Summary
- allow `build_panel` to return a suffix appended to `panel_name`
- save figures with optional suffix instead of overriding name
- update tests for suffix behavior
- clarify docstring about suffix handling
- relax test config typing

## Testing
- `poetry run ruff check src/mpl_panel_builder/panel_builder.py tests/test_panel_builder.py`
- `poetry run mypy src/mpl_panel_builder/panel_builder.py tests/test_panel_builder.py`
- `poetry run pytest -q`
- `poetry run pre-commit run --files src/mpl_panel_builder/panel_builder.py tests/test_panel_builder.py` *(fails: unable to fetch hooks due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684dcd91102c8325a52db196e2f12a59