### PR TITLE
Update Ruff config for new lint section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,11 @@ mypy_path = ["src"]
 [tool.ruff]
 line-length = 88
 target-version = "py311"
+fix = true
+
+[tool.ruff.lint]
 select = ["E", "F", "I", "B", "N", "UP", "C4", "T20", "A"]
 ignore = ["E203"]
-fix = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary
- restructure Ruff settings in `pyproject.toml`
- move lint options into `[tool.ruff.lint]`

## Testing
- `ruff check .`
- `pytest -q` *(fails: unrecognized arguments due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_684eadaa42688325b23427e64b39644a