### PR TITLE
Add panel_name requirement

### DIFF
--- a/src/mpl_panel_builder/panel_builder.py
+++ b/src/mpl_panel_builder/panel_builder.py
@@ -48,22 +48,23 @@ class PanelBuilder:
         """Validates that subclasses define required class attributes.
         
         This method ensures that any class inheriting from PanelBuilder properly
-        defines the required n_rows and n_cols class attributes that specify the
-        panel grid dimensions.
+        defines the required panel_name, n_rows and n_cols class attributes that
+        specify the panel grid dimensions.
         
         Args:
             cls: The class being defined that inherits from PanelBuilder.
             
         Raises:
-            TypeError: If the subclass does not define n_rows or n_cols.
+            TypeError: If the subclass does not define panel_name, n_rows or
+                n_cols.
         """
         super().__init_subclass__()
-        required_attrs = ['n_rows', 'n_cols']
+        required_attrs = ["panel_name", "n_rows", "n_cols"]
         missing = [attr for attr in required_attrs if not hasattr(cls, attr)]
         if missing:
             raise TypeError(
-                f"Subclasses of PanelBuilder must define class attributes: "
-                f"{', '.join(missing)}"
+                "Subclasses of PanelBuilder must define class attributes: "
+                + ", ".join(missing)
             )
 
     def __call__(self) -> MatplotlibFigure:

--- a/tests/test_panel_builder.py
+++ b/tests/test_panel_builder.py
@@ -53,6 +53,16 @@ def test_subclass_validation_raises_without_attributes() -> None:
             pass
 
 
+def test_subclass_validation_raises_without_panel_name() -> None:
+    """Ensure PanelBuilder subclass requires panel_name attribute."""
+
+    with pytest.raises(TypeError):
+
+        class InvalidPanel(PanelBuilder):
+            n_rows = 1
+            n_cols = 1
+
+
 def test_build_returns_matplotlib_figure(sample_config_dict: ConfigDict) -> None:
     """Test that calling the builder returns a matplotlib figure.
     


### PR DESCRIPTION
## Summary
- validate presence of `panel_name` in `PanelBuilder.__init_subclass__`
- test that subclasses missing `panel_name` raise `TypeError`

## Testing
- `pytest -q -o addopts="" -p no:cov tests/test_panel_builder.py::test_subclass_validation_raises_without_panel_name -vv`
- `pytest -q -o addopts="" -p no:cov`

------
https://chatgpt.com/codex/tasks/task_e_684eadc26f888325814f1e8087749600